### PR TITLE
Missing "and"

### DIFF
--- a/effectivescala.mo
+++ b/effectivescala.mo
@@ -861,7 +861,7 @@ Use the following pattern when encoding ADTs with case classes:
 .LP the type <code>Tree[T]</code> has two constructors: <code>Node</code> and <code>Leaf</code>. Declaring the type <code>sealed</code> allows the compiler to do exhaustivity analysis since constructors cannot be added outside the source file.
 
 Together with pattern matching, such modelling results in code that is
-both succinct "obviously correct":
+both succinct and "obviously correct":
 
 	def findMin[T <: Ordered[T]](tree: Tree[T]) = tree match {
 	  case Node(left, right) => Seq(findMin(left), findMin(right)).min


### PR DESCRIPTION
Missing "and".
